### PR TITLE
feat(docs): Phase 3 — glossary, ecosystem, local search, CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,131 @@
+# Contributing to Hologram Docs
+
+Thanks for helping improve the docs. This file covers the practical bits of working on the source — local setup, build/lint, content conventions, and the guardrails that keep the published site building cleanly.
+
+For *what* to write, see [`update.md`](./update.md) — the rolling content plan that tracks gaps, sources of truth, and open questions.
+
+## Local development
+
+```bash
+git clone git@github.com:2060-io/hologram-docs.git
+cd hologram-docs
+npm install
+npm run start          # http://localhost:3000, hot reload
+```
+
+Node **20 or newer** is required (matches the CI gate). Use `nvm use 20` or your platform equivalent.
+
+## Build verification
+
+Before opening a PR, the docs must build cleanly:
+
+```bash
+npm run build
+```
+
+This runs Docusaurus with `onBrokenLinks: 'throw'` and `onBrokenAnchors: 'throw'`. Any broken cross-link or fragment fails the build. The same command runs as a PR gate via [`.github/workflows/build.yml`](./.github/workflows/build.yml) — your PR cannot merge until it passes.
+
+If the build fails locally, the most common causes are:
+
+- A relative link to a moved page → fix the path.
+- An anchor that no longer exists → fix the heading or update the anchor.
+- An MDX parse error from un-escaped `<` or `>` in code-adjacent text → wrap in backticks or fence as a code block.
+
+## Content conventions
+
+### Information architecture
+
+The site has four top-level sections, each with its own sidebar:
+
+- **`/learn`** — concepts. Read once, understand the model.
+- **`/build`** — hands-on. Quickstart, agent-pack reference, how-tos, cookbook.
+- **`/run`** — deploy and operate. Local, Kubernetes, CI/CD.
+- **`/reference`** — exhaustive lookups. Schemas, env vars, APIs, glossary.
+
+A new page belongs in **`/build/how-to`** if it answers "how do I X?", **`/build/cookbook`** if it walks through a complete real agent end-to-end, and **`/build/agent-pack/<topic>.md`** if it documents one block of the agent-pack manifest.
+
+### Style
+
+- **Frontmatter** is optional. Pages without frontmatter use the H1 as title and inherit a position from the sidebars file. Add frontmatter only when you need a non-default title or sidebar position.
+- **Heading levels** start at H1 (one per page) and never skip. Use sentence case for headings.
+- **Code blocks** must declare a language (` ```yaml `, ` ```bash `, ` ```ts `) so syntax highlighting works.
+- **Cross-links** are relative paths to `.md` files (Docusaurus rewrites them at build): `[**RBAC**](../agent-pack/rbac.md)`. Anchors use the auto-generated slug from the heading: `[**access modes**](./mcp.md#access-modes)`.
+- **External links** open in the same tab unless they're explicitly an external service (DocSearch, GitHub deeply linked into a file → fine to leave default-target).
+- **Tables** use the GFM pipe form. The MD060 lint warning about whitespace is ignored — Docusaurus renders both compact and padded tables identically.
+- **Admonitions** (`:::note`, `:::tip`, `:::warning`, `:::danger`) are the supported callout style. Don't invent your own block format.
+
+### Diagrams
+
+Two options:
+
+1. **Plain code-block ASCII** for sequence-style diagrams. Renders fine on every theme. Used in most pages.
+2. **Kroki / PlantUML via the `remark-kroki` plugin** for anything that benefits from a real diagram. Wrap the source in a ` ```plantuml ` block and the build will fetch a rendered SVG from `kroki.io`.
+
+PlantUML themes don't have a dark-mode variant (yet), so an SVG generated for the light theme will look slightly off in dark mode. Acceptable for now.
+
+### Source-of-truth pages
+
+A few pages are **vendored from upstream repos** (currently just `docs/reference/agent-pack-schema.md`, sourced from [`hologram-generic-ai-agent-vs/docs/agent-pack-schema.md`](https://github.com/2060-io/hologram-generic-ai-agent-vs/blob/main/docs/agent-pack-schema.md)). When upstream changes:
+
+1. Re-paste the file content.
+2. Wrap any unquoted generics (`map<string,string>`) in backticks so MDX doesn't choke.
+3. Bump the banner at the top to mention the new commit ref if you want pinning.
+
+The same page **must not** be edited locally except for the MDX-safety wrapping in step 2 — locally-introduced drift breaks the source-of-truth invariant.
+
+### What canonical sources to use
+
+When writing a new page, prefer to base your content on:
+
+- **Agent Pack schema** → [`hologram-generic-ai-agent-vs/docs/agent-pack-schema.md`](https://github.com/2060-io/hologram-generic-ai-agent-vs/blob/main/docs/agent-pack-schema.md).
+- **Env vars** → [`hologram-generic-ai-agent-vs/README.md`](https://github.com/2060-io/hologram-generic-ai-agent-vs#environment-variables) §Environment Variables.
+- **RBAC + approval spec** → [`hologram-generic-ai-agent-vs/docs/rbac-approval-spec.md`](https://github.com/2060-io/hologram-generic-ai-agent-vs/blob/main/docs/rbac-approval-spec.md).
+- **RAG / Memory / Ollama how-tos** → the matching files in [`hologram-generic-ai-agent-vs/docs/`](https://github.com/2060-io/hologram-generic-ai-agent-vs/tree/main/docs).
+- **Helm chart** → [`hologram-generic-ai-agent-vs/charts/`](https://github.com/2060-io/hologram-generic-ai-agent-vs/tree/main/charts).
+- **Per-agent CI/CD pattern** → [`hologram-verifiable-services`](https://github.com/2060-io/hologram-verifiable-services) workflows.
+- **Admin API / webhook events** → [`vs-agent/doc/vs-agent-api.md`](https://github.com/2060-io/vs-agent/blob/main/doc/vs-agent-api.md).
+- **Pillars / messaging** → [`hologram.zone-website/src/app/page.tsx`](https://github.com/2060-io/hologram.zone-website/blob/main/src/app/page.tsx) (the marketing site is the source for the four pillars).
+
+If you find yourself re-deriving content that lives in one of these — stop and reference the canonical source instead. Drift between the docs and these repos is the most common kind of staleness.
+
+## Proposing changes
+
+The repo lives at <https://github.com/2060-io/hologram-docs>.
+
+1. **Open an issue** before any non-trivial change — it's faster to align scope than to rewrite a PR.
+2. **Branch from `main`** — `feat/<topic>` for new content, `fix/<topic>` for corrections, `chore/<topic>` for infra.
+3. **Commit messages** follow [Conventional Commits](https://www.conventionalcommits.org/): `feat(docs): …`, `fix(docs): …`, `chore: …`. Multi-line messages are encouraged for content PRs — the first line goes into the changelog, the body explains the *why*.
+4. **PR titles** mirror the commit subject. Body should describe the change in 2–5 lines and link the issue.
+5. **Build must pass.** The CI gate runs `npm run build`; broken links or anchors fail.
+
+## Repository layout
+
+```text
+hologram-docs/
+├─ docs/                 # The site content. Four sidebars, one folder each.
+│  ├─ learn/             # /learn — concepts.
+│  ├─ build/             # /build — hands-on.
+│  │  ├─ agent-pack/     # Agent-pack section reference.
+│  │  ├─ how-to/         # Task-focused recipes.
+│  │  ├─ cookbook/       # End-to-end agent walkthroughs.
+│  │  └─ advanced/       # Bare VS Agent territory.
+│  ├─ run/               # /run — deployment + ops.
+│  └─ reference/         # /reference — exhaustive lookups.
+├─ src/                  # Site components (homepage, custom React).
+├─ static/               # Assets served verbatim.
+│  ├─ img/               # Diagrams + screenshots.
+│  └─ llms.txt           # LLM-friendly docs index.
+├─ docusaurus.config.ts  # Site config.
+├─ sidebars.ts           # Sidebar definitions (one per top-level section).
+└─ update.md             # Rolling content plan.
+```
+
+The published site (build output) goes to `build/`, gitignored. Don't commit it.
+
+## Deployment
+
+The site is built and deployed to GitHub Pages by [`.github/workflows/deploy.yml`](./.github/workflows/deploy.yml) on every push to `main`. There's no preview environment for PRs — the build gate (`build.yml`) is the substitute. If a PR build is green, the eventual production deploy will be too.
+
+## Questions / discussion
+
+Open an issue, tag the right folks, or jump in `#docs` on the Hologram Discord.

--- a/docs/build/how-to/verify-a-credential.md
+++ b/docs/build/how-to/verify-a-credential.md
@@ -38,7 +38,17 @@ docker run -p 3001:3001 -p 3000:3000 \
 The easiest flow for requesting a **Verifiable Presentation** is to create an invitation code for a `proof-request`. In this way, users will scan a QR with their Hologram app
 
 
-For starters, we'll ask for a credential issued by our [Demo Chatbot Agent](https://dm.chatbot.demos.2060.io/qr), who will happily issue you a Phone Number credential when you select `Issue Credential` on its contextual menu (TODO: link to Hologram app tutorial about using it with Chatbot demo). Make sure to get a credential of this type in Hologram app before running this flow.
+For starters, we'll ask for any credential the user already holds in their Hologram app. The simplest case is the **Avatar credential** that every Hologram user receives from [`avatar.vs.hologram.zone`](https://avatar.vs.hologram.zone) when they first connect — but the same flow works for any credential definition you trust.
+
+:::tip Get a credential definition id
+The `credentialDefinitionId` for the issuer you want to verify against is published on that issuer's DID document. The fastest way to grab one for testing is to fetch the avatar issuer's DID:
+
+```bash
+curl -s https://avatar.vs.hologram.zone/.well-known/did.json | jq '.verifiableCredential[]'
+```
+
+Look for the `credentialDefinitionId` of an `avatar` schema. Or substitute with the credDef you created in [Issuing Verifiable Credentials](./issue-a-credential.md) — both are W3C-resolvable.
+:::
 
 All we need is to generate a QR code by going to VS Agent's Swagger UI and scroll to [**POST /v1/invitation/presentation-request**](http://localhost:3000/api#/invitation/InvitationController_createPresentationRequest) method.
 
@@ -50,9 +60,9 @@ There we can try it out using the following request body:
   "callbackUrl": "http://your-local-ip:4001/presentations",
   "requestedCredentials": [
     {
-      "credentialDefinitionId": "did:web:dm.chatbot.demos.2060.io?service=anoncreds&relativeRef=/credDef/3YSvM4eydm7V9V5o9nWmVh5wbDi5F6fMGuf4L7hNwFyT",
+      "credentialDefinitionId": "<credential-definition-id from the issuer's did.json>",
       "attributes": [
-        "phoneNumber"
+        "name"
       ]
     }
   ]

--- a/docs/learn/ecosystem.md
+++ b/docs/learn/ecosystem.md
@@ -1,0 +1,89 @@
+# The Hologram ecosystem
+
+Beyond the docs, Hologram is a network of running agents on the public internet. This page is the **map**. It points at the canonical reference deployments, the source repos behind them, and what each one demonstrates — useful when you're picking a starter to fork or trying to understand "what's possible".
+
+There are two public umbrellas:
+
+- **[`vs.hologram.zone`](https://vs.hologram.zone)** — the production-grade verifiable-services demos. Long-running, Verana trust-resolved, the agents that ship with the platform.
+- **[`demos.hologram.zone`](https://demos.hologram.zone)** — short-lived demos and reference deployments built off [`hologram-ai-agent-example`](https://github.com/2060-io/hologram-ai-agent-example) so you can fork-and-go.
+
+## Recommended starting point
+
+If you're new and want to ship a verifiable AI agent of your own, the path is:
+
+1. **Fork [`hologram-ai-agent-example`](https://github.com/2060-io/hologram-ai-agent-example)** — a complete starter agent with Context7 MCP wired up, Avatar-credential authentication, a Helm chart, and a GHA deploy workflow.
+2. **(Optionally) Fork [`hologram-ai-agent-example-deps`](https://github.com/2060-io/hologram-ai-agent-example-deps)** — the trust-anchor + Avatar credential issuer that the example agent depends on. Most builders won't need to redeploy these — `demos.hologram.zone` already runs them — but the repo exists if you want to operate your own trust hierarchy.
+3. Walk the [**Quickstart**](../build/quickstart.md), then [**Cookbook → Hologram example agent**](../build/cookbook/hologram-example-agent.md).
+
+That's it. Everything below is context — useful background but not gating.
+
+## Core repos
+
+| Repo | What it is | Read it when |
+|---|---|---|
+| [`hologram-ai-agent-example`](https://github.com/2060-io/hologram-ai-agent-example) | The canonical fork-and-ship starter for an AI agent. Single agent pack, Helm chart, GHA workflow. | You want to build an agent from scratch. |
+| [`hologram-ai-agent-example-deps`](https://github.com/2060-io/hologram-ai-agent-example-deps) | The Organization + Avatar issuers that the example agent trusts. Deployed at `{organization,avatar}.demos.hologram.zone`. | You need your own trust-anchor / avatar issuer instead of leaning on the public demos. |
+| [`hologram-generic-ai-agent-vs`](https://github.com/2060-io/hologram-generic-ai-agent-vs) | The **engine**. The chatbot container that reads an agent pack, talks to a VS Agent, runs the LLM, dispatches MCP tools. Published as `io2060/hologram-generic-ai-agent`. | You want to understand internals, contribute, or fork the chatbot itself. |
+| [`hologram-verifiable-services`](https://github.com/2060-io/hologram-verifiable-services) | The reference deployments behind `vs.hologram.zone`. One folder per service, GHA workflow per service. | You want production-grade examples — RBAC, multi-tenant ingress, layered trust deps. |
+| [`vs-agent`](https://github.com/2060-io/vs-agent) | The DIDComm endpoint + wallet. Published as `io2060/vs-agent`. | You want to use the VS Agent primitives directly without the chatbot — see [Advanced — bare VS Agent](../build/advanced/bare-vs-agent.md). |
+
+## What each demo demonstrates
+
+### `vs.hologram.zone` — production-grade verifiable services
+
+| Service | Domain | What's interesting |
+|---|---|---|
+| **Organization** | `organization.vs.hologram.zone` | The trust anchor. Holds Organization + Service ECS credentials from Verana, runs its own trust registry, issues Service credentials to the other agents. Pure VS Agent — no chatbot. |
+| **Avatar** | `avatar.vs.hologram.zone` | A DIDComm chatbot whose only job is to issue Avatar credentials to new Hologram users. Pattern for any credential-issuing chatbot. |
+| **Passport** | `passport.vs.hologram.zone` | NFC ePassport reader + liveness check, issues an identity credential. Pattern for hardware-backed identity flows. |
+| **GitHub agent** | `github-agent.vs.hologram.zone` | An AI agent with **user-controlled MCP**. Each user supplies their own GitHub PAT; the agent only ever sees that user's repos. See [**Cookbook — GitHub agent**](../build/cookbook/github-agent.md). |
+| **Wise agent** | `wise-agent.vs.hologram.zone` | An AI agent with **admin-controlled MCP + RBAC + approvals**. One company Wise sandbox, role-gated tool access, two-party approval on `send_money`. See [**Cookbook — Wise agent**](../build/cookbook/wise-agent.md). |
+| **Playground** | `vs.hologram.zone` | The landing page that links to all of the above. |
+
+Source: [`hologram-verifiable-services`](https://github.com/2060-io/hologram-verifiable-services). Each service is one folder with `config.env`, `deployment.yaml`, an `agent-pack.yaml` if it's an AI agent, and a per-service GHA workflow.
+
+### `demos.hologram.zone` — fork-and-go reference
+
+| Service | Domain | What's interesting |
+|---|---|---|
+| **Example agent** | `example.demos.hologram.zone` | The agent built from `hologram-ai-agent-example`. Context7 MCP, Avatar auth, no RBAC. Mirror of what the quickstart deploys. |
+| **Organization (demo)** | `organization.demos.hologram.zone` | The example's trust anchor. Built from `hologram-ai-agent-example-deps`. |
+| **Avatar (demo)** | `avatar.demos.hologram.zone` | The example's Avatar issuer. Built from `hologram-ai-agent-example-deps`. |
+
+These exist so you can run the quickstart against living, accessible dependencies — no need to deploy your own trust anchor on day one.
+
+## How they relate
+
+```text
+                        ┌──────────────────────────────────┐
+                        │          Verana network          │
+                        │     (public trust registry)      │
+                        └────────────────┬─────────────────┘
+                                         │ ECS credentials
+                                         │ (Organization, Service)
+                                         ▼
+       ┌─────────────────────────┐   ┌─────────────────────────┐
+       │ organization.vs.hologr… │   │ organization.demos.holo…│
+       │   (production trust     │   │  (demo trust anchor)    │
+       │    anchor)              │   │                         │
+       └───────┬─────────────────┘   └───────┬─────────────────┘
+               │ issues Service cred         │ issues Service cred
+               │                             │
+   ┌───────────┼───────────┐         ┌───────┴───────┐
+   ▼           ▼           ▼         ▼               ▼
+ avatar    github-agent  wise…   avatar.demos…   example.demos…
+ passport                                            (your fork
+                                                     deploys here)
+```
+
+The example agent on `demos.hologram.zone` and the production agents on `vs.hologram.zone` are **operationally identical** — same chart, same GHA pattern. The only difference is which trust anchor they chain back to.
+
+## Where to go next
+
+| You want to | Go to |
+|---|---|
+| Build your first agent | [**Quickstart**](../build/quickstart.md) |
+| Understand what a Hologram agent is | [**Agents**](./agents.md) |
+| Understand the trust model | [**Trust**](./trust.md) |
+| Pick a cookbook walkthrough | [**Cookbook**](../build/cookbook/hologram-example-agent.md) |
+| Deploy your own trust anchor | [`hologram-ai-agent-example-deps` README](https://github.com/2060-io/hologram-ai-agent-example-deps) |

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -1,0 +1,219 @@
+# Glossary
+
+Controlled vocabulary for Hologram, Verana, and the wider verifiable-credential / DIDComm stack. Linked from across the docs whenever a term appears in a new context.
+
+## Core Hologram terms
+
+### Agent (Hologram agent)
+
+A **DIDComm-reachable peer** with a verifiable identity, presented to users as a chat. Concretely: a [VS Agent](#vs-agent-verifiable-service-agent) running an [Agent Pack](#agent-pack), reachable at a stable [DID](#did-decentralised-identifier). Users connect to it from the [Hologram app](#hologram-app) and exchange messages, credentials, and tool calls over [DIDComm](#didcomm).
+
+See [**Agents**](../learn/agents.md).
+
+### Agent Pack
+
+A **single-file YAML manifest** (`agent-pack.yaml`) declaring an agent's entire configuration: which LLM, which MCP servers, which credentials it accepts for authentication, which roles map to which tools, language strings, RAG sources. The chatbot reads the pack at startup; nothing about the agent's *behaviour* lives in code.
+
+See [**Agent Pack overview**](../build/agent-pack/overview.md), [**Schema reference**](./agent-pack-schema.md).
+
+### Approval (workflow)
+
+A **two-party authorisation** policy in [RBAC](#rbac-role-based-access-control). Some tools (e.g. `send_money`) are configured with a list of approver roles + a timeout; calls submitted by users without those roles are queued, the approvers are notified in their chat, and the tool only executes after one of them taps `Approve`. If no approver acts within the timeout, the request expires.
+
+See [**RBAC → Approval lifecycle**](../build/agent-pack/rbac.md#approval-lifecycle).
+
+### Bundled tool
+
+A tool that ships with the chatbot itself rather than being supplied by an external [MCP server](#mcp-model-context-protocol). Examples: `statisticsFetcher`, `rag_retriever`, `image_generator`. Configured under `tools.bundled` in the agent pack.
+
+### Chatbot (Hologram chatbot)
+
+The **engine container** that reads an Agent Pack, holds the conversation state for each connected user, dispatches LLM calls, runs MCP tool calls, applies RBAC, and forwards messages to/from a [VS Agent](#vs-agent-verifiable-service-agent). Published as `io2060/hologram-generic-ai-agent`. Source: [`hologram-generic-ai-agent-vs`](https://github.com/2060-io/hologram-generic-ai-agent-vs).
+
+### Controller
+
+The **agent's logic side** — anything that drives a [VS Agent](#vs-agent-verifiable-service-agent) over its admin API. The chatbot is one controller. You can write your own — see [**Advanced — bare VS Agent**](../build/advanced/bare-vs-agent.md).
+
+### Hologram app
+
+The **end-user mobile app** ([hologram.zone/apps](https://hologram.zone/apps)). Holds the user's Avatar credential, surfaces the agents they've connected to as chats, lets them issue/receive/present credentials. iOS + Android + Web.
+
+### Verifiable Service / VS
+
+A specific kind of [agent](#agent-hologram-agent) registered as a discoverable, trust-resolvable service on the [Verana](#verana) network. Distinct from a private bilateral agent in that anyone resolving its [DID](#did-decentralised-identifier) gets back a signed Linked-VP confirming what kind of service it is and who endorsed it.
+
+### VS Agent (Verifiable-Service Agent)
+
+The **DIDComm endpoint container** that holds the agent's wallet, public DID, and connections. Exposes a REST admin API (port 3000) for the controller and a public DIDComm port (3001) for peers. Published as `io2060/vs-agent`. Source: [`vs-agent`](https://github.com/2060-io/vs-agent).
+
+In docs: when we say "VS Agent" without "Hologram" we mean the container; when we say "agent" we usually mean "the whole thing" (VS Agent + chatbot + agent pack).
+
+See [**Admin API**](./admin-api.md), [**Webhook events**](./webhook-events.md).
+
+### Verifiable User Agent / VUA
+
+The **user-side counterpart** to a VS — the Hologram app, treated as an agent in its own right. Holds the user's wallet, presents credentials on the user's behalf. Conceptually distinct from a Verifiable Service so the trust model can talk about user-side and service-side agents separately.
+
+### Verifiable Public Registry / VPR
+
+The **chain-of-trust registry** that makes verifiable services discoverable. Concretely instantiated on [Verana](#verana). Stores: which DIDs are recognised organizations, which credential schemas are canonical, which services are registered against which schemas.
+
+## Trust + credential primitives
+
+### AnonCreds
+
+The **default credential format** in the Hologram stack. Privacy-preserving (selective disclosure, predicates, unlinkable presentations). The credentialDefinitionId you see throughout the docs is an AnonCreds primary identifier.
+
+W3C JSON-LD credentials are also supported but currently less ergonomic.
+
+### Credential definition (credDef)
+
+The **public artefact** an issuer publishes that defines the schema + revocation registry of a particular credential type. Every issued credential references a `credentialDefinitionId`. In Hologram these are published on the issuer's DID document under the `verifiableCredential` array.
+
+### DID (Decentralised Identifier)
+
+A **W3C URI** that resolves to a DID document containing public keys, service endpoints, and (in the Hologram stack) Linked Verifiable Presentations. `did:web` is the default for VS Agents (`did:web:my-agent.demos.hologram.zone`); `did:webvh` is supported for verifiable-history use cases.
+
+### DIDComm
+
+The **DID-secured messaging protocol**. Asynchronous, encrypted, peer-to-peer. Every message between a Hologram user and an agent — text, credential offer, presentation request — is a DIDComm message under the hood. Spec: [didcomm.org](https://didcomm.org).
+
+### ECS credential
+
+A credential issued by **Verana's Ecosystem Credential Service**. Two types in routine use: **Organization** (proves an entity is a registered organization) and **Service** (proves an organization-issued service is what it claims to be). Service credentials are what give a Hologram agent its blue-check on the Verana trust resolver.
+
+### Holder
+
+The **party in possession** of a credential. Usually a user (their Hologram app), occasionally an agent (an agent holding a Service credential issued by its parent organization).
+
+### Issuer
+
+The **party that signs and emits** a credential. Hologram issuers are typically `vs-agent`-only services like `avatar.vs.hologram.zone` or `passport.vs.hologram.zone`.
+
+### Linked VP / Linked Verifiable Presentation
+
+A **signed VP attached to a DID document** as proof of an attribute about the DID itself. The mechanism by which an agent proves "I'm a registered Service of organization X" without requiring a runtime presentation — the proof is sitting on the DID doc.
+
+### Presentation / Verifiable Presentation (VP)
+
+A **proof a holder constructs** showing they hold one or more credentials matching a verifier's request, optionally with selective disclosure or predicates ("I'm over 18" without revealing date of birth).
+
+### Proof of Trust
+
+The **chain of credentials** an agent shows on first contact: my DID → I hold a Service credential issued by org X → org X holds an Organization credential issued by Verana. The Hologram app verifies this chain before letting the user message the agent.
+
+### Schema
+
+The **shape of a credential** — list of attribute names + types. Distinct from a credential definition (which binds a schema to a particular issuer's keys + revocation registry). Schemas are typically published on Verana so multiple issuers can issue against the same schema.
+
+### Trust Registry
+
+A **named set of trusted DIDs + credential definitions** published on Verana. An agent points at one or more trust registries to declare "I trust credentials issued by any of these issuers, no further checks needed".
+
+### Trust Resolver
+
+The **lookup component** that, given a DID, returns its current Linked VPs and resolves the chain of trust back to a recognised root. Hologram apps run a built-in trust resolver against Verana; you can also run a standalone instance — see [`verana-resolver`](https://github.com/verana-labs/verana-resolver).
+
+### VC (Verifiable Credential)
+
+The W3C-spec **signed claim** about a subject (usually a holder). Issued by an issuer, held by the holder, optionally presented to verifiers. Hologram uses AnonCreds-format VCs by default.
+
+### Verana
+
+The **public chain + trust-registry network** Hologram builds on. Provides the VPR primitives, the ECS credentials, and the trust-resolver protocol. See [verana.io](https://verana.io).
+
+### Verifier
+
+The **party that requests and validates** a presentation. An AI agent that requires authentication is a verifier in this sense — see [**Authentication**](../build/agent-pack/authentication.md).
+
+## Build / config primitives
+
+### accessMode
+
+The MCP-server config field that picks **who supplies credentials** to the server: `admin-controlled` (one set of credentials in env vars, shared across all users) vs `user-controlled` (each user supplies their own through an in-chat config flow). See [**MCP**](../build/agent-pack/mcp.md).
+
+### approver
+
+A **role** listed in an `approval` block. Users holding any approver role can approve queued tool calls from users without sufficient role. See [**RBAC → Approval lifecycle**](../build/agent-pack/rbac.md#approval-lifecycle).
+
+### Authentication flow
+
+The agent-pack block (`flows.authentication`) that requires users to present a credential before chatting. See [**Authentication**](../build/agent-pack/authentication.md).
+
+### MCP (Model Context Protocol)
+
+The **standard for exposing tools to LLMs** introduced by Anthropic. A black-box server exposes `list_tools` + `call_tool`; the LLM gets a typed tool catalogue. Hologram agents declare MCP servers in `mcp.servers`; the chatbot wires them into the LLM's tool list at runtime. Spec: [modelcontextprotocol.io](https://modelcontextprotocol.io).
+
+### MCP_CONFIG_ENCRYPTION_KEY
+
+The **AES-256-GCM key** the chatbot uses to encrypt user-supplied MCP credentials at rest in Postgres. Generated once with `openssl rand -hex 32`. **Rotation = data loss** — every user has to reconfigure their MCP servers. Treat as permanent.
+
+### RAG (Retrieval-Augmented Generation)
+
+The **pattern of grounding LLM answers** on a corpus of documents. The chatbot includes a RAG layer with Redis or Pinecone vector stores; configured under `rag` in the agent pack. See [**RAG**](../build/agent-pack/rag.md).
+
+### RBAC (Role-Based Access Control)
+
+The **mechanism for gating MCP tools** by user role. Roles come from the verified credential's `rolesAttribute`; tool sets per role are declared in `mcp.servers[].toolAccess.roles`. Includes optional approval workflows for sensitive tools. See [**RBAC**](../build/agent-pack/rbac.md).
+
+### rolesAttribute
+
+The **credential attribute name** the chatbot reads to resolve a user's roles. Typically `roles` (a comma-separated string or array). Configured under `flows.authentication.rolesAttribute`.
+
+### toolAccess
+
+The MCP-server config block that declares **per-role tool visibility** + approval policies. See [**MCP**](../build/agent-pack/mcp.md) and [**RBAC**](../build/agent-pack/rbac.md).
+
+### userConfig
+
+The MCP-server config block (only meaningful with `accessMode: user-controlled`) that declares **per-user fields** the user must fill in: name, type (`secret` / `string`), label (i18n key), header template. See [**MCP**](../build/agent-pack/mcp.md).
+
+## Operational / infra
+
+### Helm chart (`hologram-generic-ai-agent-chart`)
+
+The **Kubernetes deployment unit** for an AI agent. Bundles VS Agent (via the `vs-agent-chart` dependency), the chatbot, Postgres, Redis. Configured by a per-deployment `values.yaml` (see `deployment.yaml` in the demo repos). See [**Helm chart**](../run/kubernetes/helm-chart.md).
+
+### nameOverride
+
+The Helm value used to **run multiple agents in one namespace** without resource collisions. Standard pattern across `vs.hologram.zone`. See [**Helm chart**](../run/kubernetes/helm-chart.md).
+
+### ngrok
+
+The **localhost-tunnelling tool** the local dev flow uses to expose the VS Agent at a public DID-resolvable URL. Required because `did:web:localhost` won't trust-resolve. See [**Run locally**](../run/local.md).
+
+### Service credential
+
+The ECS credential a child agent receives from its parent organization, attached as a Linked VP to its DID document, allowing the Verana trust resolver to confirm "this DID is a registered service of organization X". The CI/CD `get-credentials` step issues this. See [**CI/CD**](../run/ci-cd.md).
+
+### Trust anchor
+
+The **organization at the top of an agent's chain of trust**. Typically a `vs-agent`-only deployment with no chatbot. Public examples: `organization.vs.hologram.zone`, `organization.demos.hologram.zone`. See [`hologram-ai-agent-example-deps`](https://github.com/2060-io/hologram-ai-agent-example-deps).
+
+### Webhook events
+
+The **POST callbacks** the VS Agent makes to its controller (the chatbot) when something happens — connection state changes, message received, message delivered. See [**Webhook events**](./webhook-events.md).
+
+## Common acronyms
+
+| Acronym | Expansion | Section |
+|---|---|---|
+| AI | Artificial Intelligence | n/a |
+| AnonCreds | Anonymous Credentials | [link](#anoncreds) |
+| API | Application Programming Interface | n/a |
+| credDef | Credential Definition | [link](#credential-definition-creddef) |
+| DID | Decentralised Identifier | [link](#did-decentralised-identifier) |
+| DIDComm | DID Communication | [link](#didcomm) |
+| ECS | Ecosystem Credential Service | [link](#ecs-credential) |
+| LLM | Large Language Model | n/a |
+| MCP | Model Context Protocol | [link](#mcp-model-context-protocol) |
+| OOB | Out-of-Band (DIDComm protocol) | n/a |
+| PAT | Personal Access Token | n/a |
+| RBAC | Role-Based Access Control | [link](#rbac-role-based-access-control) |
+| RAG | Retrieval-Augmented Generation | [link](#rag-retrieval-augmented-generation) |
+| VC | Verifiable Credential | [link](#vc-verifiable-credential) |
+| VP | Verifiable Presentation | [link](#presentation--verifiable-presentation-vp) |
+| VPR | Verifiable Public Registry | [link](#verifiable-public-registry--vpr) |
+| VS | Verifiable Service | [link](#verifiable-service--vs) |
+| VUA | Verifiable User Agent | [link](#verifiable-user-agent--vua) |
+| VT | Verifiable Trust | n/a |

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -38,6 +38,21 @@ const config: Config = {
     locales: ['en'],
   },
 
+  themes: [
+    [
+      require.resolve('@easyops-cn/docusaurus-search-local'),
+      /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
+      ({
+        hashed: true,
+        indexBlog: false,
+        indexPages: false,
+        docsRouteBasePath: '/docs',
+        highlightSearchTermsOnTargetPage: true,
+        explicitSearchResultPath: true,
+      }),
+    ],
+  ],
+
   presets: [
     [
       'classic',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@docusaurus/core": "^3.8.0",
         "@docusaurus/preset-classic": "^3.8.0",
+        "@easyops-cn/docusaurus-search-local": "^0.55.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "prism-react-renderer": "^2.3.0",
@@ -3623,6 +3624,156 @@
         "node": ">=18.0"
       }
     },
+    "node_modules/@easyops-cn/autocomplete.js": {
+      "version": "0.38.1",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/autocomplete.js/-/autocomplete.js-0.38.1.tgz",
+      "integrity": "sha512-drg76jS6syilOUmVNkyo1c7ZEBPcPuK+aJA7AksM5ZIIbV57DMHCywiCr+uHyv8BE5jUTU98j/H7gVrkHrWW3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "immediate": "^3.2.3"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local": {
+      "version": "0.55.1",
+      "resolved": "https://registry.npmjs.org/@easyops-cn/docusaurus-search-local/-/docusaurus-search-local-0.55.1.tgz",
+      "integrity": "sha512-jmBKj1J+tajqNrCvECwKCQYTWwHVZDGApy8lLOYEPe+Dm0/f3Ccdw8BP5/OHNpltr7WDNY2roQXn+TWn2f1kig==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/plugin-content-docs": "^2 || ^3",
+        "@docusaurus/theme-translations": "^2 || ^3",
+        "@docusaurus/utils": "^2 || ^3",
+        "@docusaurus/utils-common": "^2 || ^3",
+        "@docusaurus/utils-validation": "^2 || ^3",
+        "@easyops-cn/autocomplete.js": "^0.38.1",
+        "@node-rs/jieba": "^1.6.0",
+        "cheerio": "^1.0.0",
+        "clsx": "^2.1.1",
+        "comlink": "^4.4.2",
+        "debug": "^4.2.0",
+        "fs-extra": "^10.0.0",
+        "klaw-sync": "^6.0.0",
+        "lunr": "^2.3.9",
+        "lunr-languages": "^1.4.0",
+        "mark.js": "^8.11.1",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "@docusaurus/theme-common": "^2 || ^3",
+        "open-ask-ai": "^0.7.3",
+        "react": "^16.14.0 || ^17 || ^18 || ^19",
+        "react-dom": "^16.14.0 || 17 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "open-ask-ai": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@easyops-cn/docusaurus-search-local/node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -3769,6 +3920,271 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@node-rs/jieba": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba/-/jieba-1.10.4.tgz",
+      "integrity": "sha512-GvDgi8MnBiyWd6tksojej8anIx18244NmIOc1ovEw8WKNUejcccLfyu8vj66LWSuoZuKILVtNsOy4jvg3aoxIw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/jieba-android-arm-eabi": "1.10.4",
+        "@node-rs/jieba-android-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-arm64": "1.10.4",
+        "@node-rs/jieba-darwin-x64": "1.10.4",
+        "@node-rs/jieba-freebsd-x64": "1.10.4",
+        "@node-rs/jieba-linux-arm-gnueabihf": "1.10.4",
+        "@node-rs/jieba-linux-arm64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-arm64-musl": "1.10.4",
+        "@node-rs/jieba-linux-x64-gnu": "1.10.4",
+        "@node-rs/jieba-linux-x64-musl": "1.10.4",
+        "@node-rs/jieba-wasm32-wasi": "1.10.4",
+        "@node-rs/jieba-win32-arm64-msvc": "1.10.4",
+        "@node-rs/jieba-win32-ia32-msvc": "1.10.4",
+        "@node-rs/jieba-win32-x64-msvc": "1.10.4"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm-eabi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm-eabi/-/jieba-android-arm-eabi-1.10.4.tgz",
+      "integrity": "sha512-MhyvW5N3Fwcp385d0rxbCWH42kqDBatQTyP8XbnYbju2+0BO/eTeCCLYj7Agws4pwxn2LtdldXRSKavT7WdzNA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-android-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-android-arm64/-/jieba-android-arm64-1.10.4.tgz",
+      "integrity": "sha512-XyDwq5+rQ+Tk55A+FGi6PtJbzf974oqnpyCcCPzwU3QVXJCa2Rr4Lci+fx8oOpU4plT3GuD+chXMYLsXipMgJA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-arm64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-arm64/-/jieba-darwin-arm64-1.10.4.tgz",
+      "integrity": "sha512-G++RYEJ2jo0rxF9626KUy90wp06TRUjAsvY/BrIzEOX/ingQYV/HjwQzNPRR1P1o32a6/U8RGo7zEBhfdybL6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-darwin-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-darwin-x64/-/jieba-darwin-x64-1.10.4.tgz",
+      "integrity": "sha512-MmDNeOb2TXIZCPyWCi2upQnZpPjAxw5ZGEj6R8kNsPXVFALHIKMa6ZZ15LCOkSTsKXVC17j2t4h+hSuyYb6qfQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-freebsd-x64": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-freebsd-x64/-/jieba-freebsd-x64-1.10.4.tgz",
+      "integrity": "sha512-/x7aVQ8nqUWhpXU92RZqd333cq639i/olNpd9Z5hdlyyV5/B65LLy+Je2B2bfs62PVVm5QXRpeBcZqaHelp/bg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm-gnueabihf": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm-gnueabihf/-/jieba-linux-arm-gnueabihf-1.10.4.tgz",
+      "integrity": "sha512-crd2M35oJBRLkoESs0O6QO3BBbhpv+tqXuKsqhIG94B1d02RVxtRIvSDwO33QurxqSdvN9IeSnVpHbDGkuXm3g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-gnu/-/jieba-linux-arm64-gnu-1.10.4.tgz",
+      "integrity": "sha512-omIzNX1psUzPcsdnUhGU6oHeOaTCuCjUgOA/v/DGkvWC1jLcnfXe4vdYbtXMh4XOCuIgS1UCcvZEc8vQLXFbXQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-arm64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-arm64-musl/-/jieba-linux-arm64-musl-1.10.4.tgz",
+      "integrity": "sha512-Y/tiJ1+HeS5nnmLbZOE+66LbsPOHZ/PUckAYVeLlQfpygLEpLYdlh0aPpS5uiaWMjAXYZYdFkpZHhxDmSLpwpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-gnu": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-gnu/-/jieba-linux-x64-gnu-1.10.4.tgz",
+      "integrity": "sha512-WZO8ykRJpWGE9MHuZpy1lu3nJluPoeB+fIJJn5CWZ9YTVhNDWoCF4i/7nxz1ntulINYGQ8VVuCU9LD86Mek97g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-linux-x64-musl": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-linux-x64-musl/-/jieba-linux-x64-musl-1.10.4.tgz",
+      "integrity": "sha512-uBBD4S1rGKcgCyAk6VCKatEVQb6EDD5I40v/DxODi5CuZVCANi9m5oee/MQbAoaX7RydA2f0OSCE9/tcwXEwUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-wasm32-wasi": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-wasm32-wasi/-/jieba-wasm32-wasi-1.10.4.tgz",
+      "integrity": "sha512-Y2umiKHjuIJy0uulNDz9SDYHdfq5Hmy7jY5nORO99B4pySKkcrMjpeVrmWXJLIsEKLJwcCXHxz8tjwU5/uhz0A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-arm64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-arm64-msvc/-/jieba-win32-arm64-msvc-1.10.4.tgz",
+      "integrity": "sha512-nwMtViFm4hjqhz1it/juQnxpXgqlGltCuWJ02bw70YUDMDlbyTy3grCJPpQQpueeETcALUnTxda8pZuVrLRcBA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-ia32-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-ia32-msvc/-/jieba-win32-ia32-msvc-1.10.4.tgz",
+      "integrity": "sha512-DCAvLx7Z+W4z5oKS+7vUowAJr0uw9JBw8x1Y23Xs/xMA4Em+OOSiaF5/tCJqZUCJ8uC4QeImmgDFiBqGNwxlyA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/jieba-win32-x64-msvc": {
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/@node-rs/jieba-win32-x64-msvc/-/jieba-win32-x64-msvc-1.10.4.tgz",
+      "integrity": "sha512-+sqemSfS1jjb+Tt7InNbNzrRh1Ua3vProVvC4BZRPg010/leCbGFFiQHpzcPRfpxAXZrzG5Y0YBTsPzN/I4yHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -4149,6 +4565,16 @@
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
+      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@types/body-parser": {
@@ -5622,6 +6048,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/comlink": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/comlink/-/comlink-4.4.2.tgz",
+      "integrity": "sha512-OxGdvBmJuNKSCMO4NTl1L47VRp6xn2wG4F/2hYzB6tiCb709otOxtEYCSvK80PtjODfXXZu8ds+Nw5kVCjqd2g==",
+      "license": "Apache-2.0"
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -6736,6 +7168,31 @@
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/enhanced-resolve": {
@@ -8388,6 +8845,12 @@
         "node": ">=16.x"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+      "license": "MIT"
+    },
     "node_modules/import-fresh": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
@@ -8892,6 +9355,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/klaw-sync": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -9048,6 +9520,24 @@
       "dependencies": {
         "yallist": "^3.0.2"
       }
+    },
+    "node_modules/lunr": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+      "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+      "license": "MIT"
+    },
+    "node_modules/lunr-languages": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/lunr-languages/-/lunr-languages-1.14.0.tgz",
+      "integrity": "sha512-hWUAb2KqM3L7J5bcrngszzISY4BxrXn/Xhbb9TTCJYEGqlR1nG67/M14sp09+PTIRklobrn57IAxcdcO/ZFyNA==",
+      "license": "MPL-1.1"
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "license": "MIT"
     },
     "node_modules/markdown-code-block-meta": {
       "version": "0.0.2",
@@ -11910,6 +12400,18 @@
       "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
       "dependencies": {
         "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
         "parse5": "^7.0.0"
       },
       "funding": {
@@ -15390,6 +15892,15 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
@@ -16215,6 +16726,40 @@
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.8.0",
     "@docusaurus/preset-classic": "^3.8.0",
+    "@easyops-cn/docusaurus-search-local": "^0.55.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -13,6 +13,7 @@ const sidebars = {
     'learn/agents',
     'learn/trust',
     'learn/hologram-app',
+    'learn/ecosystem',
   ],
 
   buildSidebar: [
@@ -84,6 +85,7 @@ const sidebars = {
     'reference/env-vars',
     'reference/admin-api',
     'reference/webhook-events',
+    'reference/glossary',
   ],
 };
 

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,80 @@
+# Hologram Docs
+
+> Documentation for building verifiable AI agents on the Hologram ecosystem.
+> Hologram is a verifiable-trust + DIDComm messaging platform with a public
+> trust registry on Verana. Agents are typically built by configuring a
+> single agent-pack.yaml manifest, deployed via Docker Compose locally and
+> Helm in production. Source repos under https://github.com/2060-io/.
+
+This file follows the [llms.txt convention](https://llmstxt.org/) — it
+indexes the most useful entry points for an LLM-driven agent navigating
+this site.
+
+## Learn
+
+- [Introduction](https://docs.hologram.zone/learn/introduction): What Hologram is, the four pillars, who the docs are for.
+- [Agents](https://docs.hologram.zone/learn/agents): What a Hologram agent is — the conversation loop, the Agent Pack, where the LLM fits.
+- [Trust](https://docs.hologram.zone/learn/trust): The verifiable-trust model — VS, VUA, VPR, DIDComm, VCs, Verana.
+- [Hologram app](https://docs.hologram.zone/learn/hologram-app): The end-user app and where to find it.
+- [Ecosystem](https://docs.hologram.zone/learn/ecosystem): Map of the public agents on `vs.hologram.zone` and `demos.hologram.zone` and the source repos behind them.
+
+## Build
+
+- [Quickstart](https://docs.hologram.zone/build/quickstart): Fork-and-ship walkthrough — your first agent in 10 minutes using `hologram-ai-agent-example`.
+- [Agent Pack overview](https://docs.hologram.zone/build/agent-pack/overview): The nine top-level sections of `agent-pack.yaml`.
+
+### Agent Pack reference
+
+- [LLM](https://docs.hologram.zone/build/agent-pack/llm): OpenAI, Anthropic, Ollama, OpenAI-compatible endpoints.
+- [MCP](https://docs.hologram.zone/build/agent-pack/mcp): Model Context Protocol servers, access modes, tool access control.
+- [RBAC](https://docs.hologram.zone/build/agent-pack/rbac): Role-based access control + approval workflows.
+- [Authentication](https://docs.hologram.zone/build/agent-pack/authentication): Verifiable-credential-based authentication flow.
+- [Flows](https://docs.hologram.zone/build/agent-pack/flows): welcome / menu / authentication sub-blocks, action catalog.
+- [i18n](https://docs.hologram.zone/build/agent-pack/i18n): Multi-language config, string-key catalog.
+- [RAG](https://docs.hologram.zone/build/agent-pack/rag): Retrieval-Augmented Generation, vector stores, doc loading.
+- [Memory](https://docs.hologram.zone/build/agent-pack/memory): Conversation memory backends + window sizing.
+- [Examples](https://docs.hologram.zone/build/agent-pack/examples): Nine copy-pasteable Agent Pack snippets.
+
+### Cookbook (end-to-end walkthroughs)
+
+- [Hologram example agent](https://docs.hologram.zone/build/cookbook/hologram-example-agent): The starter pack — Context7 MCP + Avatar auth.
+- [GitHub agent](https://docs.hologram.zone/build/cookbook/github-agent): Per-user MCP pattern with PAT flow.
+- [Wise agent](https://docs.hologram.zone/build/cookbook/wise-agent): Corporate RBAC + approval pattern.
+- [Customer-service agent](https://docs.hologram.zone/build/cookbook/customer-service-agent): Flow-driven structured intake with RAG.
+
+### How-tos
+
+- [Add an MCP server](https://docs.hologram.zone/build/how-to/add-an-mcp-server): Wire a new MCP into your agent.
+- [Issue a credential](https://docs.hologram.zone/build/how-to/issue-a-credential): VS Agent primitive — bare credential issuer.
+- [Verify a credential](https://docs.hologram.zone/build/how-to/verify-a-credential): VS Agent primitive — bare verifier.
+
+### Advanced
+
+- [Bare VS Agent](https://docs.hologram.zone/build/advanced/bare-vs-agent): Run a VS Agent without the chatbot, drive it with your own controller.
+
+## Run
+
+- [Local](https://docs.hologram.zone/run/local): Docker Compose + ngrok + scripts/setup.sh + troubleshooting.
+- [Helm chart](https://docs.hologram.zone/run/kubernetes/helm-chart): Annotated `deployment.yaml`, multi-tenant pattern, secrets policy, observability.
+- [CI/CD](https://docs.hologram.zone/run/ci-cd): The `hologram-verifiable-services` GHA pattern, step-by-step.
+
+## Reference
+
+- [Agent Pack schema](https://docs.hologram.zone/reference/agent-pack-schema): Full field-by-field schema, vendored from upstream.
+- [Environment variables](https://docs.hologram.zone/reference/env-vars): Canonical table grouped by concern.
+- [Admin API](https://docs.hologram.zone/reference/admin-api): VS Agent admin REST API — endpoint groups, message-type catalog.
+- [Webhook events](https://docs.hologram.zone/reference/webhook-events): VS Agent webhook events — three topics with full schemas.
+- [Glossary](https://docs.hologram.zone/reference/glossary): Controlled vocabulary for Hologram, Verana, and the wider VC + DIDComm stack.
+
+## Source repos
+
+- [`hologram-ai-agent-example`](https://github.com/2060-io/hologram-ai-agent-example) — canonical fork-and-ship starter.
+- [`hologram-ai-agent-example-deps`](https://github.com/2060-io/hologram-ai-agent-example-deps) — Organization + Avatar trust dependencies.
+- [`hologram-generic-ai-agent-vs`](https://github.com/2060-io/hologram-generic-ai-agent-vs) — the chatbot engine.
+- [`hologram-verifiable-services`](https://github.com/2060-io/hologram-verifiable-services) — production agents at `vs.hologram.zone`.
+- [`vs-agent`](https://github.com/2060-io/vs-agent) — the DIDComm endpoint container.
+
+## Optional
+
+- [Repository](https://github.com/2060-io/hologram-docs): Source of this docs site.
+- [Contributing](https://github.com/2060-io/hologram-docs/blob/main/CONTRIBUTING.md): How to propose changes.


### PR DESCRIPTION
Wraps up the open items from `update.md` Phase 3 + a few Phase 2 carry-overs.

Builds cleanly, broken-link gate green, no anchor warnings.

## Summary

| What | Why |
|---|---|
| `docs/reference/glossary.md` | The 3.3 row on `update.md`. The single page that defines every term used elsewhere. |
| `docs/learn/ecosystem.md` | Phase 2 carry-over (was 2.16 on `update.md`). The map of public agents + source repos. |
| `CONTRIBUTING.md` (repo root) | The 3.8 row. Replaces what was in the deleted `learn/99-help.md`. |
| Local search | The 3.9 row. Default to `@easyops-cn/docusaurus-search-local` — no Algolia application required, no waiting period. |
| `static/llms.txt` | The I.11 row. Indexes the docs for LLM-driven agents per [llmstxt.org](https://llmstxt.org/). |
| `verify-a-credential.md` DID fix | Sub-item of 3.6. The `dm.chatbot.demos.2060.io` DID has been dead for a while. |

## Per file

### `docs/reference/glossary.md` (new)

Controlled vocabulary, sectioned:

- **Core Hologram terms** — Agent, Agent Pack, Approval, Bundled tool, Chatbot, Controller, Hologram app, VS / VS Agent / VUA / VPR.
- **Trust + credential primitives** — AnonCreds, credDef, DID, DIDComm, ECS credential, Holder, Issuer, Linked VP, Presentation, Proof of Trust, Schema, Trust Registry, Trust Resolver, VC, Verana, Verifier.
- **Build / config primitives** — accessMode, approver, Authentication flow, MCP, MCP_CONFIG_ENCRYPTION_KEY, RAG, RBAC, rolesAttribute, toolAccess, userConfig.
- **Operational / infra** — Helm chart, nameOverride, ngrok, Service credential, Trust anchor, Webhook events.
- **Common acronyms** — back-linked index.

Each term is one short paragraph + a link to the full reference page where applicable.

### `docs/learn/ecosystem.md` (new)

The map of running deployments + the repos behind them:

- **Recommended starting point** — `hologram-ai-agent-example` + `-deps`.
- **Core repos** — table of the five canonical 2060-io repos with "read it when" guidance.
- **`vs.hologram.zone`** services — Organization, Avatar, Passport, GitHub agent, Wise agent, Playground.
- **`demos.hologram.zone`** services — the example agent + its deps.
- **Trust-chain diagram** showing how the production and demo agents relate to Verana.

### `CONTRIBUTING.md` (new, repo root)

What was missing for external contributors:

- Local dev (`npm install`, `npm run start`, Node 20 requirement).
- Build verification + the broken-link gate.
- Content conventions (IA, headings, code blocks, cross-links, admonitions).
- Diagrams (ASCII vs. Kroki/PlantUML).
- Source-of-truth list — which upstream repos canonical content comes from.
- Repository layout.
- PR / commit-message conventions.

### Site infra

- **Local search** via `@easyops-cn/docusaurus-search-local`. Added as a `themes` entry. Default config: hashed index, no blog/page indexing, search box auto-injects into navbar.
- **`static/llms.txt`** at site root. Follows the [llmstxt.org](https://llmstxt.org/) convention — Markdown index of every docs entry point with brief descriptions, plus the source repos. Helps LLMs navigating the site.

### `verify-a-credential.md` fix

The page demonstrated requesting a credential from `dm.chatbot.demos.2060.io`, an agent that's been offline since the rebrand. Replaced with:

- A pointer at `avatar.vs.hologram.zone` (the live Avatar issuer every Hologram user already has a credential from).
- A tip block showing how to grab a current `credentialDefinitionId` from any issuer's `.well-known/did.json` — so the page can't go stale again the next time we redeploy.

## Verification

- `npm run build` — clean (broken-link gate + broken-anchor gate both pass).
- 9 broken anchors caught on first build (parenthetical heading slugs, two stale cross-page anchors); all fixed.
- The new search index ships in `build/search-index*.json` automatically.

## What's *not* in this PR

The remaining items on `update.md` worth tracking but out of scope here:

- **`learn/architecture.md`** as a stand-alone deep dive (the trust model is already covered in `learn/trust.md` + the new `ecosystem.md`).
- **Image generation + speech-to-text** Agent Pack pages (rows 2.8 / 2.9). The features are in the schema but there's no upstream how-to to base them on yet — open question 7 on `update.md` blocks this.
- **Algolia DocSearch**. Local search ships now; if we want Algolia later, it's a 5-line swap.
- **Dependabot vulnerabilities** flagged on `main`. Independent chore PR.

After this lands, every row on `update.md` Phases 1–3 has a status. The `update.md` plan can move from "rolling plan" to "history".